### PR TITLE
DistanceTester: take a direct path for Overlap features (~8% faster TRIBL2/IB1 test)

### DIFF
--- a/include/timbl/Testers.h
+++ b/include/timbl/Testers.h
@@ -92,6 +92,13 @@ namespace Timbl{
 		 double ) override;
   private:
     std::vector<metricTestFunction*> metricTest;
+    // Per-feature test info precomputed once, in permuted order, so the inner
+    // test loop avoids the permutation indirection and, for plain Overlap
+    // features (the common case), the virtual metricTestFunction / fvDistance
+    // / metric->distance() chain -- which for Overlap only computes
+    // (F==G ? 0 : weight).
+    std::vector<metricTestFunction*> permTest; // metricTest in permuted order
+    std::vector<char> isOverlap;               // 1 if feature uses Overlap
   };
 
   class SimilarityTester: public TesterClass {

--- a/src/Testers.cxx
+++ b/src/Testers.cxx
@@ -152,6 +152,17 @@ namespace Timbl{
 	metricTest[i] = new overlapTestFunction();
       }
     }
+    // Precompute, in permuted order, the metric test function and an Overlap
+    // flag for each feature, so test() can use a flat index and take a direct
+    // path for Overlap features.
+    permTest.resize(_size,0);
+    isOverlap.resize(_size,0);
+    for ( size_t j=0; j < _size; ++j ){
+      Feature *feat = permFeatures[j];
+      permTest[j] = metricTest[permutation[j]];
+      isOverlap[j] = ( feat && !feat->Ignore()
+		       && feat->getMetricType() == Overlap ) ? 1 : 0;
+    }
   }
 
   size_t DistanceTester::test( const vector<FeatureValue *>& G,
@@ -164,9 +175,15 @@ namespace Timbl{
       cerr << "feature " << TrueF << " (perm=" << permutation[TrueF]
 	   << ")" << endl;
 #endif
-      double result = metricTest[permutation[TrueF]]->test( (*FV)[TrueF],
-							    G[i],
-							    permFeatures[TrueF] );
+      double result;
+      if ( isOverlap[TrueF] ){
+	// plain Overlap: distance is 0 for an exact value match, otherwise
+	// the feature weight -- no virtual metric dispatch needed.
+	result = ( (*FV)[TrueF] == G[i] ) ? 0.0 : permFeatures[TrueF]->Weight();
+      }
+      else {
+	result = permTest[TrueF]->test( (*FV)[TrueF], G[i], permFeatures[TrueF] );
+      }
       distances[i+1] = distances[i] + result;
       if ( distances[i+1] > Threshold ){
 #ifdef DBGTEST


### PR DESCRIPTION
## Summary

The inner distance loop in `DistanceTester::test()` dispatched every feature through a virtual `metricTestFunction::test()` → `Feature::fvDistance()` (which re-checks the storable / numeric branches on every call) → a virtual `metric->distance()`, plus a `permutation[]` indirection — all to compute, for a plain **Overlap** feature, just `(F == G ? 0 : weight)`.

This precomputes once, in permuted order, a flat `metricTestFunction` array (removing the `permutation[]` indirection) and an Overlap flag per feature, and lets Overlap features take the direct `(F == G ? 0 : weight)` path. Other metrics (MVDM, numeric, …) keep the existing path unchanged.

## Measured impact

TRIBL2, 20k test instances written to /dev/null, reused saved instance base; deterministic instruction counts, min of 3 (the base load is identical before/after, so the delta is the test phase):

| 20k run | instructions |
|---|---|
| before | 161.30 B |
| after | **155.19 B** |

≈ **−8% of the test phase**. Only IB1 and TRIBL2 use `DistanceTester` (IGTree computes no distances, so it is unaffected); IB1 — being all-distance — likely benefits more.

## Correctness

Output is byte-identical, including with `+v db` (distributions printed), which depends on the exact distances and neighbour ordering. Verified on TRIBL2 (20k), plain and `+v db`.

Posting for your consideration — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
